### PR TITLE
feat: add Education and Certifications sections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,9 @@ import "@/i18n";
 import { Footer } from "@/components/layout/Footer";
 import { Header } from "@/components/layout/Header";
 import { AboutSection } from "@/components/sections/AboutSection";
+import { CertificationsSection } from "@/components/sections/CertificationsSection";
 import { ContactSection } from "@/components/sections/ContactSection";
+import { EducationSection } from "@/components/sections/EducationSection";
 import { ExperienceSection } from "@/components/sections/ExperienceSection";
 import { HeroSection } from "@/components/sections/HeroSection";
 import { ProjectsSection } from "@/components/sections/ProjectsSection";
@@ -28,6 +30,8 @@ function App() {
         <HeroSection />
         <AboutSection />
         <ExperienceSection />
+        <EducationSection />
+        <CertificationsSection />
         <SkillsSection />
         <ProjectsSection />
         <ContactSection />

--- a/src/__tests__/integration.test.tsx
+++ b/src/__tests__/integration.test.tsx
@@ -71,6 +71,6 @@ describe("App integration", () => {
     const main = container.querySelector("#main-content");
     expect(main).toBeInTheDocument();
     const children = main?.children;
-    expect(children).toHaveLength(6);
+    expect(children).toHaveLength(8);
   });
 });

--- a/src/components/layout/Header.test.tsx
+++ b/src/components/layout/Header.test.tsx
@@ -24,18 +24,20 @@ describe("Header", () => {
     expect(logo).toHaveAttribute("href", "#hero");
   });
 
-  it("renders all 6 navigation links with correct hrefs", () => {
+  it("renders all 8 navigation links with correct hrefs", () => {
     render(<Header />);
     const nav = screen.getByTestId("header").querySelector("nav");
     expect(nav).toBeTruthy();
 
     const links = nav?.querySelectorAll("a");
-    expect(links?.length).toBe(6);
+    expect(links?.length).toBe(8);
 
     const hrefs = Array.from(links ?? []).map((link) => link.getAttribute("href"));
     expect(hrefs).toContain("#hero");
     expect(hrefs).toContain("#about");
     expect(hrefs).toContain("#experience");
+    expect(hrefs).toContain("#education");
+    expect(hrefs).toContain("#certifications");
     expect(hrefs).toContain("#skills");
     expect(hrefs).toContain("#projects");
     expect(hrefs).toContain("#contact");

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -10,6 +10,8 @@ const NAV_ITEMS = [
   { key: "home", href: "#hero" },
   { key: "about", href: "#about" },
   { key: "experience", href: "#experience" },
+  { key: "education", href: "#education" },
+  { key: "certifications", href: "#certifications" },
   { key: "skills", href: "#skills" },
   { key: "projects", href: "#projects" },
   { key: "contact", href: "#contact" },

--- a/src/components/sections/CertificationsSection.tsx
+++ b/src/components/sections/CertificationsSection.tsx
@@ -1,0 +1,81 @@
+import { Chip, Surface } from "@heroui/react";
+import { ExternalLink } from "lucide-react";
+import { motion } from "motion/react";
+import { certifications } from "@/data/certifications";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+import { useTranslation } from "@/i18n";
+import { fadeUpVariants } from "@/utils/animation";
+import { formatDate, getSafeLocale } from "@/utils/locale";
+
+export function CertificationsSection() {
+  const { t, i18n } = useTranslation();
+  const prefersReducedMotion = useReducedMotion();
+  const locale = getSafeLocale(i18n.language);
+
+  return (
+    <section id="certifications" data-testid="certifications-section" className="py-16 md:py-24">
+      <div className="mx-auto max-w-5xl px-4 md:px-6">
+        <div className="mb-8 flex justify-center">
+          <div className="h-1 w-16 bg-[var(--accent)] rounded-full" />
+        </div>
+
+        <div className="mb-8 text-center">
+          <span className="terminal-label mb-4">{t("certifications.label")}</span>
+          <h2 className="text-3xl font-bold md:text-4xl">{t("certifications.title")}</h2>
+        </div>
+
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          {certifications.map((cert, index) => (
+            <motion.div
+              key={cert.id}
+              variants={prefersReducedMotion ? undefined : fadeUpVariants}
+              initial={prefersReducedMotion ? undefined : "hidden"}
+              whileInView={prefersReducedMotion ? undefined : "visible"}
+              viewport={{ once: true }}
+              transition={prefersReducedMotion ? undefined : { delay: index * 0.1 }}
+            >
+              <Surface
+                variant="secondary"
+                className="shell-panel h-full rounded-[1.25rem] border border-[var(--border-strong)] bg-[color-mix(in_oklab,var(--surface)_90%,transparent)] shadow-[0_18px_60px_rgba(0,0,0,0.16)]"
+              >
+                <div className="space-y-4 p-6">
+                  <div className="flex items-center gap-2">
+                    <span className="h-2 w-2 rounded-full bg-[var(--accent)]" />
+                    <span className="font-mono text-[11px] tracking-[0.22em] text-[var(--muted-foreground)] uppercase">
+                      {cert.issuer}
+                    </span>
+                  </div>
+
+                  <h3 className="text-lg font-semibold text-[var(--foreground)]">{t(cert.name)}</h3>
+
+                  <div className="flex flex-wrap items-center gap-2">
+                    {cert.date && (
+                      <Chip
+                        size="sm"
+                        variant="secondary"
+                        className="border-[var(--border-strong)] bg-[var(--surface-elevated)]/70 font-mono text-[11px] tracking-[0.08em] text-[var(--foreground)]"
+                      >
+                        {formatDate(cert.date, locale)}
+                      </Chip>
+                    )}
+                    {cert.url && (
+                      <a
+                        href={cert.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1.5 font-mono text-[11px] tracking-[0.08em] text-[var(--accent)] transition-colors hover:text-[var(--foreground)]"
+                      >
+                        <ExternalLink size={12} />
+                        {t("certifications.viewCertificate")}
+                      </a>
+                    )}
+                  </div>
+                </div>
+              </Surface>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/EducationSection.tsx
+++ b/src/components/sections/EducationSection.tsx
@@ -1,0 +1,121 @@
+import { Card, Chip } from "@heroui/react";
+import { motion } from "motion/react";
+import { education } from "@/data/education";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+import { useTranslation } from "@/i18n";
+import { fadeUpVariants } from "@/utils/animation";
+import { formatDate, getSafeLocale } from "@/utils/locale";
+
+export function EducationSection() {
+  const { t, i18n } = useTranslation();
+  const prefersReducedMotion = useReducedMotion();
+  const locale = getSafeLocale(i18n.language);
+
+  return (
+    <section id="education" data-testid="education-section" className="py-16 md:py-24">
+      <div className="mx-auto max-w-5xl px-4 md:px-6">
+        <div className="mb-8 flex justify-center">
+          <div className="h-1 w-16 rounded-full bg-[var(--accent)]" />
+        </div>
+
+        <div className="mb-10 text-center">
+          <span className="terminal-label mb-4">{t("education.label")}</span>
+          <h2 className="text-3xl font-bold md:text-4xl">{t("education.title")}</h2>
+        </div>
+
+        <div className="space-y-5">
+          {education.map((inst, index) => (
+            <motion.div
+              key={inst.id}
+              variants={prefersReducedMotion ? undefined : fadeUpVariants}
+              initial={prefersReducedMotion ? undefined : "hidden"}
+              whileInView={prefersReducedMotion ? undefined : "visible"}
+              viewport={{ once: true }}
+              transition={prefersReducedMotion ? undefined : { delay: index * 0.08 }}
+              className="mx-auto w-full max-w-4xl"
+            >
+              <Card className="shell-panel relative border border-[var(--border-strong)] bg-[color-mix(in_oklab,var(--surface)_90%,transparent)] shadow-[0_18px_60px_rgba(0,0,0,0.16)]">
+                <div className="absolute inset-y-0 left-0 w-px bg-[linear-gradient(to_bottom,transparent,var(--accent),transparent)]" />
+
+                <Card.Header className="border-b border-[var(--border)] px-5 py-5 md:px-7">
+                  <div className="w-full">
+                    <div className="mb-2 flex items-center gap-3">
+                      <span className="font-mono text-[11px] uppercase tracking-[0.28em] text-[var(--accent)]">
+                        {inst.id}
+                      </span>
+                      {inst.courses.some((c) => c.isCurrent) && (
+                        <span className="inline-flex shrink-0 items-center rounded-full bg-emerald-500/15 px-2.5 py-0.5 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-emerald-400">
+                          {t("common.present")}
+                        </span>
+                      )}
+                    </div>
+                    <Card.Title className="text-xl md:text-2xl">
+                      {t(`education.${inst.id}.institution`)}
+                    </Card.Title>
+                    <Card.Description className="text-sm md:text-base">
+                      {t(`education.${inst.id}.location`)}
+                    </Card.Description>
+                  </div>
+                </Card.Header>
+
+                <Card.Content className="space-y-0 divide-y divide-[var(--border)] px-0">
+                  {inst.courses.map((course) => {
+                    const startDate = formatDate(course.period.start, locale);
+                    const endDate =
+                      course.period.end === "present"
+                        ? t("common.present")
+                        : formatDate(course.period.end, locale);
+                    const dateDisplay =
+                      course.period.start === course.period.end
+                        ? startDate
+                        : `${startDate} - ${endDate}`;
+
+                    return (
+                      <div key={course.id} className="px-5 py-4 md:px-7">
+                        <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                          <div className="min-w-0 space-y-1">
+                            <h4 className="text-base font-semibold leading-snug text-[var(--foreground)]">
+                              {t(`education.${inst.id}.${course.id}.degree`)}
+                            </h4>
+                            {course.hours != null && (
+                              <span className="font-mono text-[11px] text-[var(--muted-foreground)]">
+                                {course.hours.toLocaleString()}h
+                              </span>
+                            )}
+                          </div>
+                          <div className="shrink-0 inline-flex items-center rounded-full border border-[var(--border)] bg-[var(--surface-elevated)] px-3 py-1 font-mono text-[11px] tracking-[0.12em] text-[var(--muted-foreground)]">
+                            {dateDisplay}
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </Card.Content>
+
+                {(() => {
+                  const allTags = [...new Set(inst.courses.flatMap((c) => c.tags))];
+                  return allTags.length > 0 ? (
+                    <Card.Footer className="border-t border-[var(--border)] px-5 py-4 md:px-7">
+                      <div className="flex flex-wrap gap-2">
+                        {allTags.map((tag) => (
+                          <Chip
+                            key={tag}
+                            size="sm"
+                            variant="secondary"
+                            className="border-[var(--border-strong)] bg-[var(--surface-elevated)]/70 font-mono text-[11px] tracking-[0.08em] text-[var(--foreground)]"
+                          >
+                            {tag}
+                          </Chip>
+                        ))}
+                      </div>
+                    </Card.Footer>
+                  ) : null;
+                })()}
+              </Card>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/data/certifications.ts
+++ b/src/data/certifications.ts
@@ -1,0 +1,44 @@
+import type { Certification } from "@/types";
+
+export const certifications: readonly Certification[] = [
+  {
+    id: "trybe-primeiros-passos",
+    name: "certifications.trybe-primeiros-passos.name",
+    issuer: "Trybe",
+    date: "2021-12",
+    url: "https://smartcerts.co/certificate/dylrnkmy",
+  },
+  {
+    id: "trybe-intro-javascript",
+    name: "certifications.trybe-intro-javascript.name",
+    issuer: "Trybe",
+    date: "2022-01",
+  },
+  {
+    id: "trybe-fundamentos-web",
+    name: "certifications.trybe-fundamentos-web.name",
+    issuer: "Trybe",
+    date: "2022-06",
+    url: "https://www.credential.net/d717c173-88df-4521-ba51-bd2c90ad907c#acc.G8s3zc6U",
+  },
+  {
+    id: "trybe-frontend",
+    name: "certifications.trybe-frontend.name",
+    issuer: "Trybe",
+    date: "2022-08",
+    url: "https://www.credential.net/7dc4fb01-a247-42c1-8f94-41094be88fc3#acc.mNaVjWLJ",
+  },
+  {
+    id: "trybe-backend",
+    name: "certifications.trybe-backend.name",
+    issuer: "Trybe",
+    date: "2023-01",
+    url: "https://www.credential.net/2fe53b65-0c32-42c6-83d5-2faeea4270c0#acc.pusfkORE",
+  },
+  {
+    id: "limit-leader",
+    name: "certifications.limit-leader.name",
+    issuer: "Limit Leader Training",
+    date: "",
+  },
+] as const satisfies readonly Certification[];

--- a/src/data/education.ts
+++ b/src/data/education.ts
@@ -1,0 +1,52 @@
+import type { EducationInstitution } from "@/types";
+
+export const education: readonly EducationInstitution[] = [
+  // {
+  //   id: "senai",
+  //   courses: [
+  //     {
+  //       id: "analise-desenvolvimento",
+  //       period: { start: "2024-01", end: "present" },
+  //       isCurrent: true,
+  //       tags: [],
+  //     },
+  //   ],
+  // },
+  {
+    id: "trybe",
+    courses: [
+      {
+        id: "fullstack",
+        period: { start: "2022-03", end: "2023-03" },
+        isCurrent: false,
+        hours: 1500,
+        tags: [
+          "JavaScript",
+          "React",
+          "Redux",
+          "Node.js",
+          "Express",
+          "TypeScript",
+          "MySQL",
+          "MongoDB",
+          "Docker",
+          "TDD",
+          "SOLID",
+          "+34",
+        ],
+      },
+    ],
+  },
+  {
+    id: "acate",
+    courses: [
+      {
+        id: "geracao-tec",
+        period: { start: "2012-07", end: "2012-08" },
+        isCurrent: false,
+        hours: 260,
+        tags: ["PHP", "MySQL", "Desenvolvimento Web"],
+      },
+    ],
+  },
+] as const satisfies readonly EducationInstitution[];

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3,6 +3,8 @@
     "home": "Home",
     "about": "About",
     "experience": "Experience",
+    "education": "Education",
+    "certifications": "Certifications",
     "skills": "Skills",
     "projects": "Projects",
     "contact": "Contact"
@@ -44,6 +46,47 @@
         "Assembly and maintenance of computers",
         "Remote support"
       ]
+    }
+  },
+  "education": {
+    "title": "Education",
+    "label": "Formation",
+    "acate": {
+      "institution": "ACATE — Santa Catarina Technology Association",
+      "location": "Florianópolis, Santa Catarina, Brazil",
+      "geracao-tec": {
+        "degree": "Geração TEC — PHP Programming Training Course"
+      }
+    },
+    "trybe": {
+      "institution": "Trybe",
+      "location": "Distance Learning",
+      "fullstack": {
+        "degree": "Full Stack Web Development"
+      }
+    }
+  },
+  "certifications": {
+    "title": "Certifications",
+    "label": "Credentials",
+    "viewCertificate": "View Certificate",
+    "trybe-primeiros-passos": {
+      "name": "First Steps in Programming"
+    },
+    "trybe-intro-javascript": {
+      "name": "Introductory JavaScript Course"
+    },
+    "trybe-fundamentos-web": {
+      "name": "Web Development Fundamentals"
+    },
+    "trybe-frontend": {
+      "name": "Front-end Development"
+    },
+    "trybe-backend": {
+      "name": "Back-end Development"
+    },
+    "limit-leader": {
+      "name": "Limit Leader Training — Coaching, Motivation and Leadership Course"
     }
   },
   "skills": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -3,6 +3,8 @@
     "home": "Inicio",
     "about": "Acerca de",
     "experience": "Experiencia",
+    "education": "Educación",
+    "certifications": "Certificaciones",
     "skills": "Habilidades",
     "projects": "Proyectos",
     "contact": "Contacto"
@@ -44,6 +46,47 @@
         "Ensamblaje y mantenimiento de computadoras",
         "Soporte remoto"
       ]
+    }
+  },
+  "education": {
+    "title": "Educación",
+    "label": "Formación",
+    "acate": {
+      "institution": "ACATE — Asociación Catarinense de Tecnología",
+      "location": "Florianópolis, Santa Catarina, Brasil",
+      "geracao-tec": {
+        "degree": "Geração TEC — Curso de Capacitación en Programación PHP"
+      }
+    },
+    "trybe": {
+      "institution": "Trybe",
+      "location": "Educación a Distancia",
+      "fullstack": {
+        "degree": "Desarrollo Web Full Stack"
+      }
+    }
+  },
+  "certifications": {
+    "title": "Certificaciones",
+    "label": "Credenciales",
+    "viewCertificate": "Ver Certificado",
+    "trybe-primeiros-passos": {
+      "name": "Primeros pasos en la Programación"
+    },
+    "trybe-intro-javascript": {
+      "name": "Curso Introductorio de JavaScript"
+    },
+    "trybe-fundamentos-web": {
+      "name": "Fundamentos del Desarrollo Web"
+    },
+    "trybe-frontend": {
+      "name": "Desarrollo Front-end"
+    },
+    "trybe-backend": {
+      "name": "Desarrollo Back-end"
+    },
+    "limit-leader": {
+      "name": "Limit Leader Training — Curso de coaching, motivación y liderazgo"
     }
   },
   "skills": {

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -3,6 +3,8 @@
     "home": "Início",
     "about": "Sobre",
     "experience": "Experiência",
+    "education": "Educação",
+    "certifications": "Certificações",
     "skills": "Habilidades",
     "projects": "Projetos",
     "contact": "Contato"
@@ -44,6 +46,47 @@
         "Montagem e manutenção de computadores",
         "Suporte remoto"
       ]
+    }
+  },
+  "education": {
+    "title": "Educação",
+    "label": "Formação",
+    "acate": {
+      "institution": "ACATE — Associação Catarinense de Tecnologia",
+      "location": "Florianópolis, Santa Catarina, Brasil",
+      "geracao-tec": {
+        "degree": "Geração TEC — Curso de Capacitação em Programação PHP"
+      }
+    },
+    "trybe": {
+      "institution": "Trybe",
+      "location": "Ensino a Distância",
+      "fullstack": {
+        "degree": "Desenvolvimento Web Full Stack"
+      }
+    }
+  },
+  "certifications": {
+    "title": "Certificações",
+    "label": "Credenciais",
+    "viewCertificate": "Ver Certificado",
+    "trybe-primeiros-passos": {
+      "name": "Primeiros passos na Programação"
+    },
+    "trybe-intro-javascript": {
+      "name": "Curso Introdutório de JavaScript"
+    },
+    "trybe-fundamentos-web": {
+      "name": "Fundamentos do Desenvolvimento Web"
+    },
+    "trybe-frontend": {
+      "name": "Desenvolvimento Front-end"
+    },
+    "trybe-backend": {
+      "name": "Desenvolvimento Back-end"
+    },
+    "limit-leader": {
+      "name": "Limit Leader Training — Curso de coaching, motivação e liderança"
     }
   },
   "skills": {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,4 +47,28 @@ export interface Project {
   // description comes from i18n: t(`projects.${id}.description`)
 }
 
+export interface EducationInstitution {
+  readonly id: string;
+  readonly courses: readonly EducationCourse[];
+}
+
+export interface EducationCourse {
+  readonly id: string;
+  readonly period: {
+    readonly start: string; // ISO "YYYY-MM"
+    readonly end: string; // ISO "YYYY-MM" or "present"
+  };
+  readonly isCurrent: boolean;
+  readonly hours?: number;
+  readonly tags: readonly string[];
+}
+
+export interface Certification {
+  readonly id: string;
+  readonly name: string; // i18n key reference
+  readonly issuer: string;
+  readonly date: string; // ISO "YYYY-MM"
+  readonly url?: string;
+}
+
 export type Language = "en" | "pt-BR" | "es";


### PR DESCRIPTION
## 🎯 Summary

Adds two new sections — **Education** and **Certifications** — to the portfolio, filling a gap identified by cross-referencing the LinkedIn profile with the existing portfolio content.

## 📋 Changes

### 🎓 Education Section
- **Multi-course institution model** — `EducationInstitution` type supports multiple courses per institution
- **Institutions**: Trybe (Full Stack Web Development, 1500h) and ACATE (Geração TEC — PHP, 260h)
- **Features**:
  - 🏫 Institution card header with name and localized location
  - 📜 Course list with degree, period, optional hours
  - 🏷️ Aggregated tags footer (deduplicated across courses)
  - 🟢 Emerald "Present" badge for ongoing education
  - 📐 Layout fix: degree text wraps instead of period chip (`min-w-0` / `shrink-0`)

### 📜 Certifications Section
- **6 certifications**: 5 Trybe modules + Limit Leader Training
- **Features**:
  - 🔗 Credential URL links (external link icon, opens in new tab)
  - 📅 Date chips with locale-aware formatting
  - 🏷️ Issuer labels with accent dot
  - 📱 Responsive 2-column grid layout

### 🌐 Internationalization
- Full trilingual support (🇧🇷 PT-BR, 🇺🇸 EN, 🇪🇸 ES)
- Institution names, locations, degrees, and certification names all translated

## 🗂️ Files Changed (12 files, +462 lines)

| Type | Files |
|------|-------|
| 🏗️ Types | `src/types/index.ts` |
| 📊 Data | `src/data/education.ts`, `src/data/certifications.ts` |
| 🌐 i18n | `pt-BR.json`, `en.json`, `es.json` |
| 🧩 Components | `EducationSection.tsx`, `CertificationsSection.tsx` |
| 🔌 Integration | `App.tsx`, `Header.tsx` |
| 🧪 Tests | `integration.test.tsx`, `Header.test.tsx` |

## ✅ Checklist

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] Biome lint & format check passes
- [x] 58/58 tests passing
- [x] Trilingual i18n (PT-BR, EN, ES)
- [x] Terminal/shell-inspired design consistent with existing sections
- [x] Responsive layout (mobile-first)
- [x] Motion animations with `prefers-reduced-motion` support

## 📸 Section Order

```
Hero → About → Experience → 🆕 Education → 🆕 Certifications → Skills → Projects → Contact
```