### PR TITLE
fix: polyfill Intl.Locale.maximize for Node.js 24 compatibility

### DIFF
--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,5 +1,31 @@
 import "@testing-library/jest-dom/vitest";
 
+const OriginalLocale = Intl.Locale;
+
+const PatchedLocale = class extends OriginalLocale {
+  maximize() {
+    try {
+      return super.maximize();
+    } catch {
+      return new OriginalLocale(this.toString());
+    }
+  }
+
+  minimize() {
+    try {
+      return super.minimize();
+    } catch {
+      return new OriginalLocale(this.toString());
+    }
+  }
+};
+
+Object.defineProperty(Intl, "Locale", {
+  writable: true,
+  configurable: true,
+  value: PatchedLocale,
+});
+
 Object.defineProperty(window, "matchMedia", {
   writable: true,
   value: (query: string) => ({


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes `RangeError: Incorrect locale information provided` thrown by `react-aria`'s `useDefaultLocale` → `isRTL` call chain during test execution.

## 🔍 Root Cause

`Intl.Locale.prototype.maximize()` is broken in Node.js v24.14.1 — throws `RangeError` for any locale string. Since `react-aria` (used by `@heroui/react`) calls `.maximize()` without try-catch in its RTL detection logic, **10 out of 19 test files** were crashing at setup time.

## ✅ Fix

Polyfill `Intl.Locale` in `test-setup.ts` with safe fallback:

```ts
const PatchedLocale = class extends OriginalLocale {
  maximize() {
    try { return super.maximize(); }
    catch { return new OriginalLocale(this.toString()); }
  }
  minimize() {
    try { return super.minimize(); }
    catch { return new OriginalLocale(this.toString()); }
  }
};
```

## 📊 Before / After

| Metric | Before | After |
|--------|--------|-------|
| Test files passed | 9/19 ❌ | **19/19** ✅ |
| Tests passed | 58/58* | **124/124** ✅ |
| Pre-commit hook | ❌ FAIL | ✅ PASS |

*58 tests ran because 10 files crashed before any tests could execute.

## 📁 Files Changed

| File | Change |
|------|--------|
| `src/test-setup.ts` | +26 lines (Intl.Locale polyfill) |

## ✅ Checklist

- [x] TypeScript check passes (`tsc --noEmit`)
- [x] Biome lint & format passes
- [x] 124/124 tests passing
- [x] Pre-commit hook passes (tsc + biome + vitest)